### PR TITLE
MANTA-1936 Rip out syslog logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,6 @@
 [submodule "deps/manta-scripts"]
 	path = deps/manta-scripts
 	url = https://github.com/joyent/manta-scripts.git
-	branch = MANTA-1936
 [submodule "deps/eng"]
 	path = deps/eng
 	url = https://github.com/joyent/eng.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,16 @@
 [submodule "deps/jsstyle"]
-    path = deps/jsstyle
-    url = https://github.com/joyent/jsstyle.git
+	path = deps/jsstyle
+	url = https://github.com/joyent/jsstyle.git
 [submodule "deps/restdown"]
-    path = deps/restdown
-    url = https://github.com/trentm/restdown.git
+	path = deps/restdown
+	url = https://github.com/trentm/restdown.git
 [submodule "deps/javascriptlint"]
-    path = deps/javascriptlint
-    url = https://github.com/davepacheco/javascriptlint.git
+	path = deps/javascriptlint
+	url = https://github.com/joyent/javascriptlint.git
 [submodule "deps/manta-scripts"]
-    path = deps/manta-scripts
-    url = https://github.com/joyent/manta-scripts.git
+	path = deps/manta-scripts
+	url = https://github.com/joyent/manta-scripts.git
 	branch = MANTA-1936
 [submodule "deps/eng"]
-    path = deps/eng
-    url = https://github.com/joyent/eng.git
+	path = deps/eng
+	url = https://github.com/joyent/eng.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,16 @@
 [submodule "deps/jsstyle"]
-	path = deps/jsstyle
-	url = https://github.com/joyent/jsstyle.git
+    path = deps/jsstyle
+    url = https://github.com/joyent/jsstyle.git
 [submodule "deps/restdown"]
-	path = deps/restdown
-	url = https://github.com/trentm/restdown.git
+    path = deps/restdown
+    url = https://github.com/trentm/restdown.git
 [submodule "deps/javascriptlint"]
-	path = deps/javascriptlint
-	url = https://github.com/davepacheco/javascriptlint.git
+    path = deps/javascriptlint
+    url = https://github.com/davepacheco/javascriptlint.git
 [submodule "deps/manta-scripts"]
-	path = deps/manta-scripts
-	url = https://github.com/joyent/manta-scripts.git
+    path = deps/manta-scripts
+    url = https://github.com/joyent/manta-scripts.git
+	branch = MANTA-1936
 [submodule "deps/eng"]
-	path = deps/eng
-	url = https://github.com/joyent/eng.git
+    path = deps/eng
+    url = https://github.com/joyent/eng.git

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -134,7 +134,7 @@ echo "Setting up buckets-api"
 wait_for_resolv_conf
 manta_setup_buckets_api
 
-manta_setup_common2_log_rotation "buckets-api"
+manta_common2_setup_log_rotation "buckets-api"
 
 manta_common2_setup_end
 

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -136,6 +136,6 @@ manta_setup_buckets_api
 
 manta_buckets_setup_common_log_rotation "buckets-api"
 
-manta_common_setup_end
+manta_buckets_common_setup_end
 
 exit 0

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -123,7 +123,7 @@ manta_common_presetup
 echo "Adding local manifest directories"
 manta_add_manifest_dir "/opt/smartdc/buckets-api"
 
-manta_common_setup "buckets-api"
+manta_buckets_common_setup "buckets-api"
 
 manta_ensure_zk
 
@@ -133,6 +133,8 @@ echo "Setting up buckets-api"
 # Sometimes buckets-api instances come up before DNS resolvers are in /etc/resolv.conf
 wait_for_resolv_conf
 manta_setup_buckets_api
+
+manta_buckets_setup_common_log_rotation "buckets-api"
 
 manta_common_setup_end
 

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -115,70 +115,6 @@ function manta_setup_buckets_api {
         >>/root/.bashrc
 }
 
-
-function manta_setup_buckets_api_rsyslogd {
-    #rsyslog was already set up by common setup- this will overwrite the
-    # config and restart since we want buckets-api to log locally.
-    local domain_name=$(json -f ${METADATA} domain_name)
-    [[ $? -eq 0 ]] || fatal "Unable to domain name from metadata"
-
-    mkdir -p /var/tmp/rsyslog/work
-    chmod 777 /var/tmp/rsyslog/work
-
-    cat > /etc/rsyslog.conf <<"HERE"
-$MaxMessageSize 64k
-
-$ModLoad immark
-$ModLoad imsolaris
-$ModLoad imudp
-
-
-$template bunyan,"%msg:R,ERE,1,FIELD:(\{.*\})--end%\n"
-
-*.err;kern.notice;auth.notice           /dev/sysmsg
-*.err;kern.debug;daemon.notice;mail.crit    /var/adm/messages
-
-*.alert;kern.err;daemon.err         operator
-*.alert                     root
-
-*.emerg                     *
-
-mail.debug                  /var/log/syslog
-
-auth.info                   /var/log/auth.log
-mail.info                   /var/log/postfix.log
-
-$WorkDirectory /var/tmp/rsyslog/work
-$ActionQueueType Direct
-$ActionQueueFileName mantafwd
-$ActionResumeRetryCount -1
-$ActionQueueSaveOnShutdown on
-
-HERE
-
-        cat >> /etc/rsyslog.conf <<HERE
-
-# Support node bunyan logs going to local0 and forwarding
-# only as logs are already captured via SMF
-local0.* /var/log/buckets-api.log;bunyan
-
-HERE
-
-        cat >> /etc/rsyslog.conf <<"HERE"
-$UDPServerAddress 127.0.0.1
-$UDPServerRun 514
-
-HERE
-
-    svcadm restart system-log
-    [[ $? -eq 0 ]] || fatal "Unable to restart rsyslog"
-
-    #log pulling
-    manta_add_logadm_entry "buckets-api" "/var/log" "exact"
-}
-
-
-
 # Mainline
 
 echo "Running common setup scripts"
@@ -197,7 +133,6 @@ echo "Setting up buckets-api"
 # Sometimes buckets-api instances come up before DNS resolvers are in /etc/resolv.conf
 wait_for_resolv_conf
 manta_setup_buckets_api
-manta_setup_buckets_api_rsyslogd
 
 manta_common_setup_end
 

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -123,7 +123,7 @@ manta_common_presetup
 echo "Adding local manifest directories"
 manta_add_manifest_dir "/opt/smartdc/buckets-api"
 
-manta_buckets_common_setup "buckets-api"
+manta_common2_setup "buckets-api"
 
 manta_ensure_zk
 
@@ -134,8 +134,8 @@ echo "Setting up buckets-api"
 wait_for_resolv_conf
 manta_setup_buckets_api
 
-manta_buckets_setup_common_log_rotation "buckets-api"
+manta_setup_common2_log_rotation "buckets-api"
 
-manta_buckets_common_setup_end
+manta_common2_setup_end
 
 exit 0

--- a/etc/config.coal.json
+++ b/etc/config.coal.json
@@ -1,11 +1,7 @@
 {
     "clearProxyPort": 9080,
     "bunyan": {
-        "level": "info",
-        "syslog": {
-            "facility": "local0",
-            "type": "udp"
-        }
+        "level": "info"
     },
     "throttle": {
         "enabled": false,
@@ -37,12 +33,12 @@
         }
     },
     "marlin": {
-	"moray": {
+    "moray": {
             "srvDomain": "1.moray.coal.joyent.us",
             "cueballOptions": {
                 "resolvers": [ "nameservice.coal.joyent.us" ]
             }
-	},
+    },
         "jobCache": {
             "size": 500,
             "expiry": 30
@@ -96,7 +92,7 @@
                 "resolvers": ["nameservice.coal.joyent.us"]
             }
         },
-	"defaultMaxStreamingSizeMB": 5120
+    "defaultMaxStreamingSizeMB": 5120
     },
     "sharkConfig": {
         "connectTimeout": 2000,

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -181,7 +181,6 @@ function configureLogging(appName, bunyanCfg, verbose) {
 
     var log = bunyan.createLogger({
         name: appName,
-        level: level,
         streams: streams,
         serializers: restify.bunyan.serializers
     });

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -160,7 +160,7 @@ function configureLogging(appName, bunyanCfg, verbose) {
 
     if (level >= bunyan.INFO) {
         /*
-         * We want debug info only IF the request fails AND the configured
+         * We want debug info IFF the request fails AND the configured
          * log level is info or higher.
          */
         const RequestCaptureStream = restify.bunyan.RequestCaptureStream;

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -160,7 +160,7 @@ function configureLogging(appName, bunyanCfg, verbose) {
 
     if (level >= bunyan.INFO) {
         /*
-         * We want debug info only IFF the request fails AND the configured
+         * We want debug info only IF the request fails AND the configured
          * log level is info or higher.
          */
         const RequestCaptureStream = restify.bunyan.RequestCaptureStream;

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -128,18 +128,27 @@ function configure(appName, opts, dtProbes) {
  * Configure the logger based on the configuration data
  *
  * @param {String} appName: Required. The name of the application
- * @param {Object} bunyanCfg: Required. The bunyan configuration data
- * @param {arrayOfBool} verbose: Required. Array of boolean values that
+ * @param {Object} bunyanCfg: Optional. The bunyan configuration data
+ * @param {arrayOfBool} verbose: Optional. Array of boolean values that
  * indicates if verbose logging should be enabled and the level of verbosity
  * requested.
  * @returns {Object} A bunyan logger object
  */
 function configureLogging(appName, bunyanCfg, verbose) {
+    assert.optionalObject(bunyanCfg, 'config.bunyan');
+
     var level;
     if (bunyanCfg) {
-        level = process.env.LOG_LEVEL || bunyanCfg.level || 'info';
+        assert.optionalString(bunyanCfg.level, 'config.bunyan.level');
+
+        level = bunyan.resolveLevel(process.env.LOG_LEVEL ||
+                    bunyanCfg.level || 'info');
     } else {
-        level = process.env.LOG_LEVEL || 'info';
+        level = bunyan.resolveLevel(process.env.LOG_LEVEL || 'info');
+    }
+
+    if (verbose) {
+        level = Math.max(bunyan.TRACE, (level - verbose.length * 10));
     }
 
     var streams = [];
@@ -149,17 +158,11 @@ function configureLogging(appName, bunyanCfg, verbose) {
             stream: process.stderr
     });
 
-    assert.object(bunyanCfg, 'config.bunyan');
-    assert.optionalString(bunyanCfg.level, 'config.bunyan.level');
-
-    level = bunyan.resolveLevel(process.env.LOG_LEVEL ||
-                                bunyanCfg.level ||
-                                'info');
-    /*
-     * We want debug info only IFF the request fails AND the configured
-     * log level is info or higher.
-     */
     if (level >= bunyan.INFO) {
+        /*
+         * We want debug info only IFF the request fails AND the configured
+         * log level is info or higher.
+         */
         const RequestCaptureStream = restify.bunyan.RequestCaptureStream;
         streams.push({
             level: 'debug',
@@ -184,14 +187,14 @@ function configureLogging(appName, bunyanCfg, verbose) {
     });
 
     /*
-     * If the configured logging level is at or below DEBUG then enable source
-     * logging.
+     * If the configured logging level is at or below DEBUG then enable
+     * source logging.
      */
     if (level <= bunyan.DEBUG) {
         log = log.child({src: true});
     }
 
-    log.debug('Bunyan log level: ' + level);
+    log.debug('bunyan log level: ' + level);
 
     return (log);
 }

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -13,7 +13,6 @@ var fs = require('fs');
 var artedi = require('artedi');
 var assert = require('assert-plus');
 var bunyan = require('bunyan');
-var bsyslog = require('bunyan-syslog');
 var restify = require('restify');
 
 ///--- Constants
@@ -132,8 +131,7 @@ function configure(appName, opts, dtProbes) {
  * @param {Object} bunyanCfg: Required. The bunyan configuration data
  * @param {arrayOfBool} verbose: Required. Array of boolean values that
  * indicates if verbose logging should be enabled and the level of verbosity
- * requested. Used to determine if syslog logging should be configured or not
- * and to set the logging level appropriately.
+ * requested.
  * @returns {Object} A bunyan logger object
  */
 function configureLogging(appName, bunyanCfg, verbose) {
@@ -143,101 +141,47 @@ function configureLogging(appName, bunyanCfg, verbose) {
     } else {
         level = process.env.LOG_LEVEL || 'info';
     }
-    var log = bunyan.createLogger({
-        name: appName,
-        streams: [ {
+
+    var streams = [];
+
+    streams.push({
             level: level,
             stream: process.stderr
-        } ],
-        serializers: restify.bunyan.serializers
     });
-
-    level = log.level();
-
-    /*
-     * This is ugly, but we set this up so that if muskie is invoked with a
-     * -v flag, then we know you're running locally, and you just want the
-     * messages to spew to stderr. Otherwise, it's "production", and muskie
-     * likely logs to a syslog endpoint.
-     */
-    if (verbose || !bunyanCfg) {
-        if (verbose) {
-            level = Math.max(bunyan.TRACE, (log.level() - verbose.length * 10));
-            log.level(level);
-        }
-
-        /*
-         * If the configured logging level is at or below DEBUG then enable
-         * source logging.
-         */
-        if (level <= bunyan.DEBUG) {
-            log = log.child({src: true});
-        }
-
-        return (log);
-    }
 
     assert.object(bunyanCfg, 'config.bunyan');
     assert.optionalString(bunyanCfg.level, 'config.bunyan.level');
-    assert.optionalObject(bunyanCfg.syslog, 'config.bunyan.syslog');
 
     level = bunyan.resolveLevel(process.env.LOG_LEVEL ||
                                 bunyanCfg.level ||
                                 'info');
-
-    log.debug('Bunyan log level: ' + level);
-
-    if (bunyanCfg.syslog) {
-        var streams = [];
-        var sysl;
-
-        assert.string(bunyanCfg.syslog.facility,
-                      'config.bunyan.syslog.facility');
-        assert.string(bunyanCfg.syslog.type, 'config.bunyan.syslog.type');
-
-        sysl = bsyslog.createBunyanStream({
-            facility: bsyslog.facility[bunyanCfg.syslog.facility],
-            name: appName,
-            host: bunyanCfg.syslog.host,
-            port: bunyanCfg.syslog.port,
-            type: bunyanCfg.syslog.type
-        });
-
+    /*
+     * We want debug info only IFF the request fails AND the configured
+     * log level is info or higher.
+     */
+    if (level >= bunyan.INFO) {
+        const RequestCaptureStream = restify.bunyan.RequestCaptureStream;
         streams.push({
-            level: level,
-            stream: sysl
+            level: 'debug',
+            type: 'raw',
+            stream: new RequestCaptureStream({
+                level: bunyan.WARN,
+                maxRecords: 2000,
+                maxRequestIds: 2000,
+                streams: [ {
+                    raw: true,
+                    stream: process.stderr
+                }]
+            })
         });
-
-        /*
-         * We want debug info only IFF the request fails AND the configured
-         * log level is info or higher.
-         */
-        if (level >= bunyan.INFO) {
-            const RequestCaptureStream = restify.bunyan.RequestCaptureStream;
-            streams.push({
-                level: 'debug',
-                type: 'raw',
-                stream: new RequestCaptureStream({
-                    level: bunyan.WARN,
-                    maxRecords: 2000,
-                    maxRequestIds: 2000,
-                    streams: [ {
-                        raw: true,
-                        stream: sysl
-                    }]
-                })
-            });
-        }
-
-        log = bunyan.createLogger({
-            name: appName,
-            level: level,
-            streams: streams,
-            serializers: restify.bunyan.serializers
-        });
-    } else {
-        log.level(level);
     }
+
+    var log = bunyan.createLogger({
+        name: appName,
+        level: level,
+        streams: streams,
+        serializers: restify.bunyan.serializers
+    });
 
     /*
      * If the configured logging level is at or below DEBUG then enable source
@@ -246,6 +190,8 @@ function configureLogging(appName, bunyanCfg, verbose) {
     if (level <= bunyan.DEBUG) {
         log = log.child({src: true});
     }
+
+    log.debug('Bunyan log level: ' + level);
 
     return (log);
 }

--- a/main.js
+++ b/main.js
@@ -14,7 +14,6 @@ var path = require('path');
 
 var apertureConfig = require('aperture-config').config;
 var assert = require('assert-plus');
-var bsyslog = require('bunyan-syslog');
 var bunyan = require('bunyan');
 var cueball = require('cueball');
 var dashdash = require('dashdash');

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
         "bignum": "0.6.0",
         "boray": "git+https://github.com/joyent/node-buckets-mdapi.git#master",
         "bunyan": "0.22.1",
-        "bunyan-syslog": "0.2.2",
         "clone": "0.1.9",
         "cmdln": "4.3.0",
         "content-disposition": "0.5.3",

--- a/sapi_manifests/buckets-api/template
+++ b/sapi_manifests/buckets-api/template
@@ -1,11 +1,7 @@
 {
   "clearProxyPort": 81,
   "bunyan": {
-    "level": "info",
-    "syslog": {
-      "facility": "local0",
-      "type": "udp"
-    }
+    "level": "info"
   },
   "throttle": {
     {{#BUCKETS_API_THROTTLE_ENABLED}}

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var bunyan = require('bunyan');
@@ -14,18 +14,10 @@ var configure = require('../lib/configure.js');
 exports.configureLogging = function (t) {
     var appName = 'muskie';
     var bunyanCfg1 = {
-        level: 'info',
-        syslog: {
-            facility: 'local0',
-            type: 'udp'
-        }
+        level: 'info'
     };
     var bunyanCfg2 = {
-        level: 'debug',
-        syslog: {
-            facility: 'local0',
-            type: 'udp'
-        }
+        level: 'debug'
     };
 
     var bunyanCfg3 = {

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -86,8 +86,10 @@ exports.configureLogging = function (t) {
     process.env.LOG_LEVEL = '';
     var logObj8 = configure.configureLogging(appName, bunyanCfg3, null);
 
-    t.equal(logObj8.streams.length, 1);
-    t.equal(logObj8.level(), bunyan.INFO);
+    t.equal(logObj8.streams.length, 2);
+    var logObject8Levels = logObj8.levels().sort();
+    t.equal(logObject8Levels[0], bunyan.DEBUG);
+    t.equal(logObject8Levels[1], bunyan.INFO);
     t.equal(logObj8.src, false);
 
     var logObj9 = configure.configureLogging(appName, bunyanCfg3, [true]);
@@ -111,8 +113,10 @@ exports.configureLogging = function (t) {
     process.env.LOG_LEVEL = 'info';
     var logObj12 = configure.configureLogging(appName, null, null);
 
-    t.equal(logObj12.streams.length, 1);
-    t.equal(logObj12.level(), bunyan.INFO);
+    t.equal(logObj12.streams.length, 2);
+    var logObject12Levels = logObj12.levels().sort();
+    t.equal(logObject12Levels[0], bunyan.DEBUG);
+    t.equal(logObject12Levels[1], bunyan.INFO);
     t.equal(logObj12.src, false);
 
     var logObj13 = configure.configureLogging(appName, null, [true]);

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -20,14 +20,6 @@ exports.configureLogging = function (t) {
         level: 'debug'
     };
 
-    var bunyanCfg3 = {
-        level: 'info'
-    };
-
-    var bunyanCfg4 = {
-        level: 'debug'
-    };
-
     // Record the value of LOG_LEVEL so it can be restored after testing
     var startingLogLevel = process.env.LOG_LEVEL || '';
 
@@ -82,33 +74,6 @@ exports.configureLogging = function (t) {
     t.equal(logObj7.streams.length, 1);
     t.equal(logObj7.level(), bunyan.TRACE);
     t.equal(logObj7.src, true);
-
-    process.env.LOG_LEVEL = '';
-    var logObj8 = configure.configureLogging(appName, bunyanCfg3, null);
-
-    t.equal(logObj8.streams.length, 2);
-    var logObject8Levels = logObj8.levels().sort();
-    t.equal(logObject8Levels[0], bunyan.DEBUG);
-    t.equal(logObject8Levels[1], bunyan.INFO);
-    t.equal(logObj8.src, false);
-
-    var logObj9 = configure.configureLogging(appName, bunyanCfg3, [true]);
-
-    t.equal(logObj9.streams.length, 1);
-    t.equal(logObj9.level(), bunyan.DEBUG);
-    t.equal(logObj9.src, true);
-
-    var logObj10 = configure.configureLogging(appName, bunyanCfg4, null);
-
-    t.equal(logObj10.streams.length, 1);
-    t.equal(logObj10.level(), bunyan.DEBUG);
-    t.equal(logObj10.src, true);
-
-    var logObj11 = configure.configureLogging(appName, bunyanCfg4, [true]);
-
-    t.equal(logObj11.streams.length, 1);
-    t.equal(logObj11.level(), bunyan.TRACE);
-    t.equal(logObj11.src, true);
 
     process.env.LOG_LEVEL = 'info';
     var logObj12 = configure.configureLogging(appName, null, null);


### PR DESCRIPTION
This is part of the work described by RFD 142. It removes the use of syslog logging and instead relies on SMF logging for each instance of the service. The log rotation and upload changes are part of [this](https://github.com/joyent/manta-scripts/pull/4) related PR for the `manta-scripts` repo. 

Currently, I have the `manta-scripts` submodule changed to track the corresponding topic branch in the `manta-scripts` repo, but merging that change to `manta-scripts` and updating the submodule commit accordingly will be done prior to merging this PR. 

### Testing

I have been testing this work by building images and deploying them in my lab system. I have verified that the `buckets-api` instances are logging to their respective SMF log files and that the log files are properly rotated and uploaded each hour.

I have also run the `configure` module test that tests the logging configuration in `buckets-api`. A few test cases had to be updated in response to this change, but after the adjustments they are all passing now.