### PR TITLE
MANTA-3901 Add runtime metrics for bucket API operations - part 1

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -34,6 +34,9 @@ function billable(name, req) {
     case 'putjobslink':
     case 'putpubliclink':
     case 'putreportslink':
+    case 'createbucket':
+    case 'createbucketobject':
+    case 'updatebucketobjectmetadata':
         op = 'PUT';
         break;
 
@@ -42,6 +45,8 @@ function billable(name, req) {
     case 'getjobsstorage':
     case 'getpublicstorage':
     case 'getreportsstorage':
+    case 'getbucketobject':
+    case 'getbucketobjectmetadata':
         if (req.metadata && req.metadata.type === 'directory') {
             op = 'LIST';
         } else {
@@ -54,6 +59,8 @@ function billable(name, req) {
     case 'deletepublicstorage':
     case 'deletereportsstorage':
     case 'deleterootdir':
+    case 'deletebucket':
+    case 'deletebucketobject':
         op = 'DELETE';
         break;
 
@@ -70,6 +77,8 @@ function billable(name, req) {
     case 'getjoboutput':
     case 'getjobstatus':
     case 'listjobs':
+    case 'listbuckets':
+    case 'listbucketobjects':
         op = 'LIST';
         break;
 
@@ -78,6 +87,8 @@ function billable(name, req) {
     case 'headpublicstorage':
     case 'headreportsstorage':
     case 'headrootdir':
+    case 'headbucket':
+    case 'headbucketobject':
         op = 'HEAD';
         break;
 
@@ -85,6 +96,7 @@ function billable(name, req) {
     case 'optionspublicstorage':
     case 'optionsjobsstorage':
     case 'optionsreportsstorage':
+    case 'optionsbuckets':
         op = 'OPTIONS';
         break;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -610,47 +610,58 @@ function addBucketsRoutes(server) {
     }, buckets.updateBucketObjectMetadataHandler());
 
     server.post({
-        path: '/:account/buckets'
+        path: '/:account/buckets',
+        name: 'PostBuckets'
     }, methodNotAllowHandler);
 
     server.put({
-        path: '/:account/buckets'
+        path: '/:account/buckets',
+        name: 'PutBuckets'
     }, methodNotAllowHandler);
 
     server.head({
-        path: '/:account/buckets'
+        path: '/:account/buckets',
+        name: 'PutBuckets'
     }, methodNotAllowHandler);
 
     server.del({
-        path: '/:account/buckets'
+        path: '/:account/buckets',
+        name: 'DeleteBuckets'
     }, methodNotAllowHandler);
 
     server.post({
-        path: '/:account/buckets/:bucket_name/objects'
+        path: '/:account/buckets/:bucket_name/objects',
+        name: 'PostBucketObjects'
     }, methodNotAllowHandler);
 
     server.put({
-        path: '/:account/buckets/:bucket_name/objects'
+        path: '/:account/buckets/:bucket_name/objects',
+        name: 'PutBucketObjects'
     }, methodNotAllowHandler);
 
     server.head({
-        path: '/:account/buckets/:bucket_name/objects'
+        path: '/:account/buckets/:bucket_name/objects',
+        name: 'HeadBucketObjects'
     }, methodNotAllowHandler);
 
     server.del({
-        path: '/:account/buckets/:bucket_name/objects'
+        path: '/:account/buckets/:bucket_name/objects',
+        name: 'DeleteBucketObjects'
     }, methodNotAllowHandler);
 
     server.head({
-        path: '/:account/buckets/:bucket_name/objects/:object_name/metadata'
+        path: '/:account/buckets/:bucket_name/objects/:object_name/metadata',
+        name: 'HeadBucketObjectMetadata'
     }, methodNotAllowHandler);
 
     server.post({
-        path: '/:account/buckets/:bucket_name/objects/:object_name/metadata'
+        path: '/:account/buckets/:bucket_name/objects/:object_name/metadata',
+        name: 'PostBucketObjectMetadata'
     }, methodNotAllowHandler);
 
     server.del({
-        path: '/:account/buckets/:bucket_name/objects/:object_name/metadata'
+        path: '/:account/buckets/:bucket_name/objects/:object_name/metadata',
+        name: 'DeleteBucketObjectMetadata'
     }, methodNotAllowHandler);
 
 }


### PR DESCRIPTION
#### First Part:
This part adds the below set of metrics

```
- # HELP http_requests_completed count of Muskie requests completed
  # TYPE http_requests_completed counter
- # HELP http_request_latency_ms time-to-first-byte of Muskie requests
  # TYPE http_request_latency_ms histogram
- # HELP http_request_time_ms total time to process Muskie requests
  # TYPE http_request_time_ms histogram
- # HELP muskie_inbound_streamed_bytes count of object bytes streamed from client to storage
  # TYPE muskie_inbound_streamed_bytes counter
- # HELP muskie_outbound_streamed_bytes count of object bytes streamed from storage to client
  # TYPE muskie_outbound_streamed_bytes counter
 ```
At the time of this writing `http_requests_completed` and `http_request_time_ms` cover the below set of operations – which are all bucket operations supported so far:

- createbucket
- createbucketobject
- deletebucket
- deletebucketobject
- getbucketobject
- getbucketobjectmetadata
- headbucket
- headbucketobject
- listbucketobjects
- listbuckets
- optionsbuckets
- updatebucketobjectmetadata

`http_request_latency_ms` shows aggregated time-to-first-byte for:

- createbucketobject
- getbucketobject

`muskie_inbound_streamed_bytes` and `muskie_outbound_streamed_bytes` counters work as expected.