### PR TITLE
MANTA-3901 Add runtime metrics for bucket API operations - part 2

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -312,39 +312,17 @@ function auditLogger(options) {
         }
 
         /*
-         * Only count storage freed if the delete was successful. Today, all
-         * Muskie delete routes indicate success with a 204 HTTP response code.
+         * Only count storage freed if the delete was successful.
+         * Today, all buckets-api delete routes indicate success
+         * with a 204 HTTP response code.
          */
-        if (op === 'DELETE' && req.metadata && res.statusCode == 204) {
-            var md = req.metadata;
-            var owner = md.creator || md.owner;
+        if (op === 'DELETE' && res.statusCode == 204 &&
+            req.deletedObjects && req.deletedObjects.length > 0) {
 
-            /*
-             * Count bytes for which DELETE API requests have been completed. If
-             * the owner of the underlying data has snaplinks disabled, then
-             * the deleted object was processed by the accelerated deletion
-             * pipeline.
-             */
-            if (owner) {
-                common.checkAccountSnaplinksEnabled(req, owner,
-                    function (enabled) {
-                    /*
-                     * The intent of 'deleted_data_counter' is to count only
-                     * deletes that unlink object backing files from storage
-                     * node filesystems. Directory deletes, zero byte object
-                     * deletes, and snaplink deletes are omitted from this
-                     * count.
-                     */
-                    if (md.type === 'object' && md.contentLength > 0) {
-                        var storage = md.contentLength * md.sharks.length;
-                        labels = {
-                            accelerated_gc: !enabled,
-                            owner: owner
-                        };
-                        deleted_data_counter.add(storage, labels);
-                    }
-                });
-            }
+            var storage = req.deletedObjects.reduce(function (acc, dobj) {
+                return (acc + dobj.content_length * dobj.shark_count);
+            }, 0);
+            deleted_data_counter.add(storage, {});
         }
 
         log.info(obj, 'handled: %d', res.statusCode);

--- a/lib/buckets/objects/delete.js
+++ b/lib/buckets/objects/delete.js
@@ -56,6 +56,7 @@ function deleteObject(req, res, next) {
                 }, 'deleteObject: done');
 
                 req.resource_exists = true;
+                req.deletedObjects = object_data;
                 next(null, object_data);
             }
         }


### PR DESCRIPTION
This change depends on information returned by `buckets-mdapi` when an object is deleted. It should not be integrated before [buckets-mdapi/PR#13](https://github.com/joyent/buckets-mdapi/pull/13).