### PR TITLE
MANTA-4730 update metadata boray call is wrong

### DIFF
--- a/lib/buckets/objects/metadata/update.js
+++ b/lib/buckets/objects/metadata/update.js
@@ -85,7 +85,7 @@ function updateObjectMetadata(req, res, next) {
             bucket.id, bucketObject.name);
         var client = req.metadataPlacement.getBorayClient(metadataLocation);
 
-        client.updateObjectNoVnode(owner, bucket.id,
+        client.updateObject(owner, bucket.id,
             bucketObject.name, objectId, object_data.contentType,
             object_data.headers, props, metadataLocation.vnode, requestId,
             onUpdateObject);


### PR DESCRIPTION
This was inadvertently introduced in MANTA-4604