### PR TITLE
MANTA-4441 refactored 500 error for invalid delimiter parameter

### DIFF
--- a/lib/buckets/common.js
+++ b/lib/buckets/common.js
@@ -94,12 +94,13 @@ function _list(type, req, bucket_id) {
     assert.uuid(owner, 'owner');
 
     // Validate optional delimiter
-    if (delimiter && delimiter.length > 1) {
-        ee.emit('error', new Error(
-            '%s: delimiter larger than 1 character: %j',
-            funcname, delimiter));
-        return (ee);
-    }
+        if (delimiter && delimiter.length > 1) {
+            process.nextTick(function () {
+                ee.emit('error', new InvalidParameterError('delimiter',
+                    delimiter));
+            });
+            return (ee);
+        }
 
     // Validate optional limit
     var limit;

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var bunyan = require('bunyan');


### PR DESCRIPTION
## Description

Invalid Delimiter Parameter in pagination support leading to Internal Server Error `500`, resolves [MANTA-4441](https://jira.joyent.us/browse/MANTA-4441). 

## Solution

- Performs validation for the condition, when for delimiter if the supplied `string length > 1` char, we return a 400 with the appropriate server message.

