### PR TITLE
MANTA-4822 Uncaught InvalidHeaderError: Invalid Signature Authorization header:

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -900,7 +900,7 @@ module.exports = {
             } catch (e2) {
                 var err = new restifyErrors.InvalidHeaderError(
                     'Invalid Signature Authorization header: ' + e2.message);
-                throw (err);
+                return (next(err));
             }
         }
 


### PR DESCRIPTION
This is a bug that was inherited from the muskie codebase. Rather than throw in this situation we should just return a 400 error to the caller.