### PR TITLE
MANTA-4921 "Uncaught AssertionError: req.log" caused buckets-api to crash when a non-existing bucket is referenced

### DIFF
--- a/lib/buckets/buckets.js
+++ b/lib/buckets/buckets.js
@@ -74,7 +74,7 @@ function getBucketIfExists(req, res, next) {
 
     var onGetBucket = function onGet(err, bucket_data) {
         if (err) {
-            err = translateBucketError(err);
+            err = translateBucketError(req, err);
 
             log.debug({
                 err: err,
@@ -281,7 +281,7 @@ function getObject(req, res, next) {
 
     var onGetObject = function onGet(err, object_data) {
         if (err) {
-            err = translateBucketError(err);
+            err = translateBucketError(req, err);
 
             log.debug({
                 err: err,


### PR DESCRIPTION
testing notes in the ticket