### PR TITLE
MANTA-4946 Specify service name for buckets-mdplacement cueball configuration

### DIFF
--- a/sapi_manifests/buckets-api/template
+++ b/sapi_manifests/buckets-api/template
@@ -190,6 +190,7 @@
   "buckets_mdplacement": {
      "srvDomain": "{{BUCKETS_MDPLACEMENT}}",
       "cueballOptions": {
+          "service": "_buckets-mdplacement._tcp",
           "resolvers": ["nameservice.{{DOMAIN_NAME}}"]
       }
   },


### PR DESCRIPTION
This change overrides the [default service name](https://github.com/joyent/node-buckets-mdapi/blob/master/lib/client_params.js#L39) in `node-buckets-mdapi` so that the SRV record queries for `buckets-mdplacement` are issued properly. Without this change `buckets-api` ends up falling back to A record queries which work, but is not the intended mode of operation.