### PR TITLE
MANTA-5129 mlocate does not seem to work for bucket objects

### DIFF
--- a/bin/mlocate
+++ b/bin/mlocate
@@ -228,7 +228,8 @@ function lookupAndFetchData(opts, cb) {
          * The hash of the object name, not the object name itself, is included
          * in the string used to look up the object location.
          */
-        var object_hash = crypto.createHash('md5').update(opts.object).digest('hex');
+        var object_hash =
+            crypto.createHash('md5').update(opts.object).digest('hex');
         key += ':' + object_hash;
     } else {
         assert.string(opts.bucket, 'opts.bucket');

--- a/bin/mlocate
+++ b/bin/mlocate
@@ -224,7 +224,12 @@ function lookupAndFetchData(opts, cb) {
         assert.uuid(opts.bucket, 'opts.bucket');
         lookingUpObject = true;
         object = opts.object;
-        key += ':' + object;
+        /*
+         * The hash of the object name, not the object name itself, is included
+         * in the string used to look up the object location.
+         */
+        var object_hash = crypto.createHash('md5').update(opts.object).digest('hex');
+        key += ':' + object_hash;
     } else {
         assert.string(opts.bucket, 'opts.bucket');
     }


### PR DESCRIPTION
Quick fix -- had to update mlocate to use the object hash to match the changes from MANTA-4591.

See ticket for testing notes.