### PR TITLE
MANTA-4556 "update buckets object metadata" response is missing some headers

### DIFF
--- a/lib/buckets/objects/metadata/update.js
+++ b/lib/buckets/objects/metadata/update.js
@@ -83,6 +83,7 @@ function updateObjectMetadata(req, res, next) {
                 }
                 res.header('Etag', response_data.id);
                 res.header('Last-Modified', new Date(response_data.modified));
+                res.header('Durability-Level', response_data.sharks.length);
 
                 Object.keys(response_data.headers).forEach(function (k) {
                     if (/^m-\w+/.test(k)) {


### PR DESCRIPTION
Tested by deploying an image with this change to my lab and running the modified node-manta tests (https://github.com/joyent/node-manta/pull/384) against it.