### PR TITLE
MANTA-5507 manta-buckets-api should support rclone

### DIFF
--- a/lib/auth/signature-verifier.js
+++ b/lib/auth/signature-verifier.js
@@ -801,240 +801,17 @@ function sigv4Handler(req, res, next) {
             filteredHeaders['content-md5'];
     }
 
-    var urlForVerification = req.url;
-    var pathPart = urlForVerification.split('?')[0];
-    var queryPart = urlForVerification.split('?')[1];
-
-    // For virtual-hosted-style requests, the bucket name is the first
-    // component of the host header.
-    var hostHeader = req.headers.host || '';
-    var virtualHostBucketName = hostHeader.split('.')[0];
-
-    // For path-style requests, extract bucket name from the path
-    var pathStyleBucketName = null;
-    var pathSegments = pathPart.split('/').filter(
-        function isNonEmptySegment(segment) {
-        return (segment.length > 0);
-    });
-    if (pathSegments.length >= 1) {
-        pathStyleBucketName = pathSegments[0];
-    }
-
-    // Get user agent for client-specific logic
-    var userAgent = req.headers['user-agent'] || 'none';
-
-    // Determine the actual bucket name based on request style
-    var bucketName = null;
-    if (virtualHostBucketName !== hostHeader &&
-        virtualHostBucketName.length > 0) {
-        // Virtual-hosted style: bucket.domain.com
-        bucketName = virtualHostBucketName;
-        req.log.debug({
-            bucket: bucketName,
-            style: 'virtual-hosted'
-        }, 'S3_AUTH_DEBUG: Detected virtual-hosted bucket name');
-    } else if (pathStyleBucketName) {
-        // Path-style: domain.com/bucket
-        bucketName = pathStyleBucketName;
-        req.log.debug({
-            bucket: bucketName,
-            style: 'path-style'
-        }, 'S3_AUTH_DEBUG: Detected path-style bucket name');
-    }
-
-    // Check if this is a presigned request
-    // (which uses proper path canonicalization)
-    var isPresignedRequest = queryPart &&
-        (queryPart.includes('X-Amz-Algorithm') ||
-         queryPart.includes('AWSAccessKeyId'));
-
-    // Detect client types and their trailing slash behavior
-    // CLI tools and SDK v2 sign WITHOUT trailing slash
-    // SDK v3 signs WITH trailing slash
-
-    // AWS SDK v3 specifically (aws-sdk-js/3.x) - signs WITH trailing slash
-    var isAwsSdkV3 = userAgent &&
-        (userAgent.toLowerCase().includes('aws-sdk-js/3') ||
-         (userAgent.toLowerCase().includes('aws-sdk-js') &&
-          userAgent.match(/aws-sdk-js\/3/i)));
-
-    // CLI tools and AWS SDK v2 (aws-sdk-nodejs) - sign WITHOUT trailing slash
-    var isAwsCli = (userAgent &&
-        (userAgent.toLowerCase().includes('aws-cli') ||
-         userAgent.toLowerCase().includes('boto3') ||
-         userAgent.toLowerCase().includes('botocore') ||
-         userAgent.toLowerCase().includes('aws-sdk-nodejs'))) ||
-        isPresignedRequest;
-
-    // DEBUG: Log the values we're working with
-    req.log.debug({
-        bucketName: bucketName,
-        pathPart: pathPart,
-        pathMatches: bucketName && pathPart === '/' + bucketName,
-        isAwsCli: isAwsCli,
-        isAwsSdkV3: isAwsSdkV3,
-        userAgent: userAgent
-    }, 'S3_AUTH_DEBUG: Pre-bucket path logic values');
-
     /*
-     * If the URI path is the bucket name, some S3 clients sign the request
-     * with a canonical URI ending with /. We must normalize the URL we send
-     * to mahi for verification to match what the client signed.
-     * AWS CLI/boto/SDK v2 do NOT add trailing slash
-     * AWS SDK v3 and other clients DO add trailing slash
+     * Use the original URL (_rawSignedUrl) for SigV4, before
+     * MANTA-331 sanitizePath() stripped trailing slashes.
      */
-    var bucketPathHandled = false;
-    if (bucketName && pathPart === '/' + bucketName) {
-        bucketPathHandled = true;
-        if (isAwsCli) {
-            // AWS CLI, boto*, and SDK v2 sign WITHOUT trailing slash
-            req.log.debug({
-                bucket: bucketName,
-                originalPath: pathPart,
-                userAgent: userAgent
-            }, 'S3_AUTH_DEBUG: CLI/SDK v2 detected -' +
-                          ' NOT adding trailing slash for bucket URI');
-            // pathPart stays as-is (no trailing slash)
-        } else {
-            // AWS SDK v3 and other S3 clients sign WITH trailing slash
-            req.log.debug({
-                bucket: bucketName,
-                originalPath: pathPart,
-                newPath: '/' + bucketName + '/',
-                userAgent: userAgent,
-                isAwsSdkV3: isAwsSdkV3
-            }, 'S3_AUTH_DEBUG: SDK v3/S3 client detected - ' +
-                'adding trailing slash for bucket URI SigV4 verification');
-            pathPart = '/' + bucketName + '/';
-        }
-    }
-
-    /*
-     * MANTA-331 removes trailing slashes, here minio requires them
-     * to sign the request if pathPart is just a bucket request then add /
-     * Most S3 clients need trailing slash appended to bucket paths for
-     * proper SigV4 signature validation. This is needed because Manta strips
-     * trailing slashes (manta 331) but clients calculate signatures with them.
-     * AWS CLI/boto/SDK v2 are excluded as they sign without trailing slashes.
-     * AWS SDK v3 and other clients sign WITH trailing slashes.
-     * For example /bucket needs to be /bucket/ for signature validation,
-     * while /bucket/file.txt doesn't need patching.
-     */
-    var regex = /\/[^/]+\.(?:$|\/)|\/[^/]+\/[^/]+/;
-    // Exclude directory creation requests - they are handled at URL
-    // reconstruction
-    var isDirectoryCreation = req.headers['content-type'] ===
-        'application/x-directory';
-
-    // Add slash for all S3 clients EXCEPT AWS CLI/boto/SDK v2
-    var shouldAddSlash = !bucketPathHandled &&
-        !isAwsCli &&
-        !regex.test(pathPart) &&
-        pathPart !== '/' &&
-        !pathPart.endsWith('/') &&
-        !isDirectoryCreation;
+    var urlForVerification = req._rawSignedUrl || req.url;
 
     req.log.debug({
-        userAgent: userAgent,
-        pathPart: pathPart,
-        regexTest: regex.test(pathPart),
-        shouldAddSlash: shouldAddSlash,
-        isDirectoryCreation: isDirectoryCreation,
-        bucketPathHandled: bucketPathHandled,
-        isAwsCli: isAwsCli,
-        isAwsSdkV3: isAwsSdkV3,
-        originalPath: pathPart
-    }, 'S3_AUTH_DEBUG: Trailing slash logic evaluation');
-
-    if (shouldAddSlash) {
-        req.log.debug({
-            originalPath: pathPart,
-            newPath: pathPart + '/'
-        }, 'S3_AUTH_DEBUG: Adding trailing slash via regex fallback logic');
-        pathPart += '/';
-    }
-
-    // Fix double-encoding issue in query parameters before sending to mahi
-    // AWS CLI sends delimiter=%2F but when we URL-encode the whole URL for
-    // mahi, it becomes delimiter=%252F which breaks signature verification
-    // However, continuation-token parameters must preserve their exact
-    // encoding as sent by the client to match the signature.
-
-    if (queryPart) {
-        try {
-            // Check if this contains parameters that need preserved encoding
-            // for signature match
-            // Apply directory creation check when query parameters are present
-            var finalPathPart = pathPart;
-            if (isDirectoryCreation && !pathPart.endsWith('/')) {
-                finalPathPart = pathPart + '/';
-                req.log.debug({
-                    originalPath: pathPart,
-                    modifiedPath: finalPathPart
-                }, 'S3_AUTH_DEBUG: Adding trailing slash for directory ' +
-                   'creation with query params');
-            }
-
-            if (queryPart.includes('continuation-token=') ||
-                queryPart.includes('marker=') ||
-                queryPart.includes('encoding-type=') ||
-                queryPart.includes('max-keys=') ||
-                queryPart.includes('list-type=')) {
-                // For S3 listing and pagination parameters, don't decode to
-                // preserve signature match
-                urlForVerification = finalPathPart + '?' + queryPart;
-                req.log.debug({
-                    originalUrl: req.url,
-                    finalUrl: urlForVerification,
-                    reason: 'S3 listing/pagination parameter present' +
-                        ' - preserving original encoding'
-                }, 'S3_AUTH_DEBUG: Preserving query encoding' +
-                   ' for S3 listing/pagination parameters');
-            } else {
-                // For other requests, decode query parameters once to prevent
-                // double-encoding
-                var decodedQuery = decodeURIComponent(queryPart);
-                urlForVerification = finalPathPart + '?' + decodedQuery;
-                req.log.debug({
-                    originalUrl: req.url,
-                    finalUrl: urlForVerification
-                }, 'S3_AUTH_DEBUG:'+
-                ' Fixed query parameter encoding for SigV4 verification');
-            }
-        } catch (e) {
-            // If decoding fails, keep original URL but still apply directory
-            // creation logic
-            var errorFinalPathPart = pathPart;
-            if (isDirectoryCreation && !pathPart.endsWith('/')) {
-                errorFinalPathPart = pathPart + '/';
-            }
-            urlForVerification = errorFinalPathPart + '?' + queryPart;
-            req.log.debug({
-                originalUrl: req.url,
-                error: e.message,
-                reason: 'Query decoding failed, using original query part'
-            }, 'S3_AUTH_DEBUG: Using original URL for SigV4 verification');
-        }
-    } else {
-        // Apply directory creation check when setting final urlForVerification
-        if (isDirectoryCreation && !pathPart.endsWith('/')) {
-            // For directory creation requests, ensure trailing slash for
-            // signature verification
-            urlForVerification = pathPart + '/';
-            req.log.debug({
-                originalPath: pathPart,
-                finalUrl: urlForVerification,
-                reason: 'Directory creation request - adding trailing slash'
-            }, 'S3_AUTH_DEBUG: Modified URL' +
-               ' for directory creation signature verification');
-        } else {
-            urlForVerification = pathPart;
-            req.log.debug({
-                url: urlForVerification,
-                reason: 'No query parameters'
-            }, 'S3_AUTH_DEBUG: Using original URL for SigV4 verification');
-        }
-    }
+        rawSignedUrl: req._rawSignedUrl,
+        sanitizedUrl: req.url,
+        urlForVerification: urlForVerification
+    }, 'S3_AUTH_DEBUG: Using raw URL for SigV4 verification');
 
     var requestForVerification = {
         method: req.method,
@@ -1073,9 +850,7 @@ function sigv4Handler(req, res, next) {
         url: requestForVerification.url,
         originalRequestMethod: req.method,
         originalRequestUrl: req.url,
-        pathPart: pathPart,
-        queryPart: queryPart,
-        bucketName: bucketName,
+        rawSignedUrl: req._rawSignedUrl,
         authHeaderPrefix: (requestForVerification.headers.authorization ||
         '').substring(0, 50) + '...',
         hasAuthHeader: !!requestForVerification.headers.authorization,

--- a/lib/server.js
+++ b/lib/server.js
@@ -200,6 +200,11 @@ function createServer(options, clients) {
     server.pre(middleware.detectS3Uploads);
     server.pre(middleware.configureBinaryMode);
     /*
+     * Save the raw URL before sanitizePath() strips trailing slashes.
+     * SigV4 verification needs the exact URL the client signed.
+     */
+    server.pre(middleware.preserveRawUrl);
+    /*
      * MANTA-331: while a trailing '/' is ok in HTTP, this messes with
      * the consistent hashing, so ensure there isn't one by using
      * sanitizePath()

--- a/lib/server/middleware.js
+++ b/lib/server/middleware.js
@@ -536,6 +536,19 @@ function s3RequestDetectorEarly(req, res, next) {
 
 ///--- Exports
 
+/**
+ * MANTA-331 sanitizePath() strips trailing slashes, this breaks
+ * SigV4 signature validation, the S3 clients sign the original URL,
+ * but as the original URL is already tampered this will cause that
+ * all authentication attempts to fail, as signatures will NEVER match.
+ *
+ * This must be registered as a pre-routing middleware BEFORE sanitizePath().
+ */
+function preserveRawUrl(req, res, next) {
+    req._rawSignedUrl = req.url;
+    next();
+}
+
 module.exports = {
     traceTTFB: traceTTFB,
     createDependencyChecker: createDependencyChecker,
@@ -548,5 +561,6 @@ module.exports = {
     configureBinaryMode: configureBinaryMode,
     createCleanupContentType: createCleanupContentType,
     preserveRawBodyPreMiddleware: preserveRawBodyPreMiddleware,
+    preserveRawUrl: preserveRawUrl,
     s3RequestDetectorEarly: s3RequestDetectorEarly
 };


### PR DESCRIPTION
This patch preserves the original URL sent by S3 clients, bypassing MANTA-331, allowing SigV4 to work with any new S3 client.
Testing notes in the ticket.

Portions contributed by: Claude Opus 4.6 <noreply@anthropic.com>